### PR TITLE
validate properties on init

### DIFF
--- a/addon/components/a11y-landmark.js
+++ b/addon/components/a11y-landmark.js
@@ -14,7 +14,7 @@ const LANDMARK_NAVIGATION_ROLE = {
 const VALID_LANDMARK_ROLES = [
     'banner',
     'navigation',
-    'aside',
+    'complementary',
     'main',
     'search',
     'application',

--- a/addon/components/a11y-landmark.js
+++ b/addon/components/a11y-landmark.js
@@ -12,6 +12,28 @@ const LANDMARK_NAVIGATION_ROLE = {
     div: 'div'
 };
 
+const VALID_LANDMARK_ROLES = [
+    'banner',
+    'navigation',
+    'aside',
+    'main',
+    'form',
+    'search',
+    'application',
+    'document',
+    'region'
+];
+
+const VALID_TAG_NAMES = [
+    'aside',
+    'footer',
+    'form',
+    'header',
+    'main',
+    'nav',
+    'div'
+];
+
 export default Ember.Component.extend({
     layout,
 
@@ -40,6 +62,11 @@ export default Ember.Component.extend({
      */
     landmarkRole: 'region',
 
+    init() {
+        this._super(...arguments);
+        this._validateProperties();
+    },
+
     /*we should set an aria-role when either a native element is not used, or the native element does not have the body element as its parent. 
      * since nothing is going to be the direct child of the body in an Ember app, we don't have to check for that. 
      */
@@ -60,5 +87,22 @@ export default Ember.Component.extend({
         }
     }),
 
+    _validateProperties() {
+        this._validateTagName(this.tagName);
+        this._validateLandmarkRole(this.landmarkRole);
+    },
 
+    _validateTagName(tagName) {
+        if (VALID_TAG_NAMES.indexOf(tagName) === -1) {
+            const validValues = VALID_TAG_NAMES.join(', ');
+            Ember.assert(`Invalid tagName "${tagName}". Must be one of ${validValues}.`);
+        }
+    },
+
+    _validateLandmarkRole(landmarkRole) {
+        if (VALID_LANDMARK_ROLES.indexOf(landmarkRole) === -1) {
+            const validValues = VALID_LANDMARK_ROLES.join(', ');
+            Ember.assert(`Invalid tagName "${landmarkRole}". Must be one of ${validValues}.`);
+        }
+    }
 });

--- a/addon/components/a11y-landmark.js
+++ b/addon/components/a11y-landmark.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import layout from '../templates/components/a11y-landmark';
 
 const LANDMARK_NAVIGATION_ROLE = {
-    _default: 'region',
     header: 'banner',
     nav: 'navigation',
     aside: 'complementary',
@@ -17,7 +16,6 @@ const VALID_LANDMARK_ROLES = [
     'navigation',
     'aside',
     'main',
-    'form',
     'search',
     'application',
     'document',
@@ -46,7 +44,7 @@ export default Ember.Component.extend({
      * nav (navigation)
      * div (application, document, region or any of the previous)
      */
-    tagName: 'div',
+    tagName: null,
 
     /*should only be set if ('div' or 'form') is being used as a tagName, otherwise we don't need it.
      * valid values: 
@@ -60,37 +58,31 @@ export default Ember.Component.extend({
      * document
      * region (default)
      */
-    landmarkRole: 'region',
-
-    init() {
-        this._super(...arguments);
-        this._validateProperties();
-    },
+    landmarkRole: null,
 
     /*we should set an aria-role when either a native element is not used, or the native element does not have the body element as its parent. 
      * since nothing is going to be the direct child of the body in an Ember app, we don't have to check for that. 
      */
     ariaRole: Ember.computed('tagName', 'landmarkRole', function() {
         const landmark = this.get('tagName');
-        let landmarkRole = this.get('landmarkRole');
-        if (landmark === 'form' && landmarkRole === 'search') {
-            return 'search';
-        } else if (landmark === 'div') {
-            if (landmarkRole === 'form') {
-                Ember.assert('Use a form element for forms.');
-                //or search? think about this more in the context of Ember. 
-            } else {
-                return (landmarkRole);
+        const landmarkRole = this.get('landmarkRole');
+
+        if (landmark && landmarkRole) {
+            if (landmark === 'form' && landmarkRole === 'search') {
+                return 'search';
             }
+
+            Ember.assert('Cannot set both "tagName" and "landMarkRole. Use one or the other.');
+        } else if (landmarkRole) {
+            this._validateLandmarkRole(landmarkRole);
+            return landmarkRole;
+        } else if (landmark) {
+            this._validateTagName(landmark);
+            return LANDMARK_NAVIGATION_ROLE[landmark];
         } else {
-            return LANDMARK_NAVIGATION_ROLE[landmark] || LANDMARK_NAVIGATION_ROLE._default;
+            Ember.assert('Must specify either tagName or landmarkRole'); 
         }
     }),
-
-    _validateProperties() {
-        this._validateTagName(this.tagName);
-        this._validateLandmarkRole(this.landmarkRole);
-    },
 
     _validateTagName(tagName) {
         if (VALID_TAG_NAMES.indexOf(tagName) === -1) {
@@ -100,6 +92,10 @@ export default Ember.Component.extend({
     },
 
     _validateLandmarkRole(landmarkRole) {
+        if (landmarkRole === 'form') {
+            Ember.assert('Use a form element for forms.');
+        }
+
         if (VALID_LANDMARK_ROLES.indexOf(landmarkRole) === -1) {
             const validValues = VALID_LANDMARK_ROLES.join(', ');
             Ember.assert(`Invalid tagName "${landmarkRole}". Must be one of ${validValues}.`);

--- a/addon/components/a11y-landmark.js
+++ b/addon/components/a11y-landmark.js
@@ -16,6 +16,7 @@ const VALID_LANDMARK_ROLES = [
     'navigation',
     'complementary',
     'main',
+    'contentinfo',
     'search',
     'application',
     'document',

--- a/tests/integration/components/a11y-landmark-test.js
+++ b/tests/integration/components/a11y-landmark-test.js
@@ -6,17 +6,8 @@ moduleForComponent('a11y-landmark', 'Integration | Component | a11y landmark', {
 });
 
 test('it renders', function(assert) {
-
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
-  this.render(hbs`{{a11y-landmark}}`);
-
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
   this.render(hbs`
-    {{#a11y-landmark}}
+    {{#a11y-landmark tagName="form"}}
       template block text
     {{/a11y-landmark}}
   `);

--- a/tests/unit/components/a11y-landmark-test.js
+++ b/tests/unit/components/a11y-landmark-test.js
@@ -1,0 +1,32 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('a11y-landmark', 'Unit | Component | a11y landmark', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar'],
+  unit: true
+});
+
+test('it initializes with valid properties', function(assert) {
+  assert.expect(0);
+  
+  this.subject({
+    tagName: 'form',
+    landmarkRole: 'search'
+  });
+});
+
+test('it fails to init when tagName is invalid', function(assert) {
+  const expectedErrorMessage = 'Assertion Failed: Invalid tagName "someInvalidTagName". Must be one of aside, footer, form, header, main, nav, div.';
+
+  assert.throws(() => {
+    this.subject({tagName: 'someInvalidTagName'});
+  }, error => error.message === expectedErrorMessage);
+});
+
+test('it fails to init when landmarkRole is invalid', function(assert) {
+  const expectedErrorMessage = 'Assertion Failed: Invalid tagName \"someInvalidLandmarkRole\". Must be one of banner, navigation, aside, main, form, search, application, document, region.';
+
+  assert.throws(() => {
+    this.subject({landmarkRole: 'someInvalidLandmarkRole'});
+  }, error => error.message === expectedErrorMessage);
+});

--- a/tests/unit/components/a11y-landmark-test.js
+++ b/tests/unit/components/a11y-landmark-test.js
@@ -67,7 +67,7 @@ test('it fails to determine ariaRole when tagName is invalid', function(assert) 
 });
 
 test('it fails to determine ariaRole when landmarkRole is invalid', function(assert) {
-  const expectedErrorMessage = 'Invalid tagName \"someInvalidLandmarkRole\". Must be one of banner, navigation, aside, main, search, application, document, region.';
+  const expectedErrorMessage = 'Invalid tagName \"someInvalidLandmarkRole\". Must be one of banner, navigation, complementary, main, search, application, document, region.';
 
   assert.throws(() => {
     const component = this.subject({landmarkRole: 'someInvalidLandmarkRole'});

--- a/tests/unit/components/a11y-landmark-test.js
+++ b/tests/unit/components/a11y-landmark-test.js
@@ -6,27 +6,92 @@ moduleForComponent('a11y-landmark', 'Unit | Component | a11y landmark', {
   unit: true
 });
 
-test('it initializes with valid properties', function(assert) {
-  assert.expect(0);
-  
-  this.subject({
+function buildEmberAssertion(message) {
+  return {
+    "code": undefined,
+    "description": undefined,
+    "fileName": undefined,
+    "lineNumber": undefined,
+    "message": `Assertion Failed: ${message}`,
+    "name": "Error",
+    "number": undefined
+  };
+}
+
+test('it determines ariaRole with valid tagName', function(assert) {
+  const component = this.subject({
+    tagName: 'form'
+  });
+  const ariaRole = component.get('ariaRole');
+
+  assert.equal(ariaRole, 'form');
+});
+
+test('it determines ariaRole with valid landmarkRole', function(assert) {
+  const component = this.subject({
+    landmarkRole: 'region'
+  });
+  const ariaRole = component.get('ariaRole');
+
+  assert.equal(ariaRole, 'region');
+});
+
+test('it determines ariaRole when tagName is "form" and landmarkRole is "search"', function(assert) {
+  const component = this.subject({
     tagName: 'form',
     landmarkRole: 'search'
   });
+  const ariaRole = component.get('ariaRole');
+
+  assert.equal(ariaRole, 'search');
 });
 
-test('it fails to init when tagName is invalid', function(assert) {
-  const expectedErrorMessage = 'Assertion Failed: Invalid tagName "someInvalidTagName". Must be one of aside, footer, form, header, main, nav, div.';
+test('it fails to determine ariaRole when landmarkRole is "form"', function(assert) {
+  const expectedErrorMessage = 'Use a form element for forms.';
 
   assert.throws(() => {
-    this.subject({tagName: 'someInvalidTagName'});
-  }, error => error.message === expectedErrorMessage);
+    const component = this.subject({
+      landmarkRole: 'form'
+    });
+    component.get('ariaRole');
+  }, buildEmberAssertion(expectedErrorMessage));
 });
 
-test('it fails to init when landmarkRole is invalid', function(assert) {
-  const expectedErrorMessage = 'Assertion Failed: Invalid tagName \"someInvalidLandmarkRole\". Must be one of banner, navigation, aside, main, form, search, application, document, region.';
+test('it fails to determine ariaRole when tagName is invalid', function(assert) {
+  const expectedErrorMessage = 'Invalid tagName "someInvalidTagName". Must be one of aside, footer, form, header, main, nav, div.';
 
   assert.throws(() => {
-    this.subject({landmarkRole: 'someInvalidLandmarkRole'});
-  }, error => error.message === expectedErrorMessage);
+    const component = this.subject({tagName: 'someInvalidTagName'});
+    component.get('ariaRole');
+  }, buildEmberAssertion(expectedErrorMessage));
+});
+
+test('it fails to determine ariaRole when landmarkRole is invalid', function(assert) {
+  const expectedErrorMessage = 'Invalid tagName \"someInvalidLandmarkRole\". Must be one of banner, navigation, aside, main, search, application, document, region.';
+
+  assert.throws(() => {
+    const component = this.subject({landmarkRole: 'someInvalidLandmarkRole'});
+    component.get('ariaRole');
+  }, buildEmberAssertion(expectedErrorMessage));
+});
+
+test('it fails to determine ariaRole when tagName and landmarkRole are both provided', function(assert) {
+  const expectedErrorMessage = 'Cannot set both \"tagName\" and \"landMarkRole. Use one or the other.';
+
+  assert.throws(() => {
+    const component = this.subject({
+      landmarkRole: 'form',
+      tagName: 'form'
+    });
+    component.get('ariaRole');
+  }, buildEmberAssertion(expectedErrorMessage));
+});
+
+test('it fails to determine ariaRole when neither tagName nor landmarkRole are provided', function(assert) {
+  const expectedErrorMessage = 'Must specify either tagName or landmarkRole';
+
+  assert.throws(() => {
+    const component = this.subject();
+    component.get('ariaRole');
+  }, buildEmberAssertion(expectedErrorMessage));
 });

--- a/tests/unit/components/a11y-landmark-test.js
+++ b/tests/unit/components/a11y-landmark-test.js
@@ -67,7 +67,7 @@ test('it fails to determine ariaRole when tagName is invalid', function(assert) 
 });
 
 test('it fails to determine ariaRole when landmarkRole is invalid', function(assert) {
-  const expectedErrorMessage = 'Invalid tagName \"someInvalidLandmarkRole\". Must be one of banner, navigation, complementary, main, search, application, document, region.';
+  const expectedErrorMessage = 'Invalid tagName \"someInvalidLandmarkRole\". Must be one of banner, navigation, complementary, main, contentinfo, search, application, document, region.';
 
   assert.throws(() => {
     const component = this.subject({landmarkRole: 'someInvalidLandmarkRole'});


### PR DESCRIPTION
This change validates properties on `init` of the component.

It will NOT re-validate them if they change after `init`, currently. This probably should be added, just in case, though. Unfortunately, we can't use computed properties for `tagName` because Ember prevents that. Should we set up an observer?

---

Does this meet the requirements you mentioned, @MelSumner?